### PR TITLE
Site title and description revision

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,13 +2,15 @@
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-        <title>Kivy: Crossplatform Framework for NUI</title>
+        <title>Kivy: Cross-platform Python Framework for NUI Development</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta name="robots" content="index, follow"/>
-        <meta name="twitter:site" content="@kivyframework">
-        <meta property="og:title" content="Kivy: Crossplatform Framework for NUI"/>
-        <meta property="og:description" content="Open source library for rapid development of applications
-                that make use of innovative user interfaces, such as multi-touch apps, in Python / OpenGL"/>
+        <meta name="description" content="Open source Python framework for rapid development of applications
+                that make use of innovative user interfaces, such as multi-touch apps."/>
+        <meta name="twitter:site" content="@kivyframework"/>
+        <meta property="og:title" content="Kivy: Cross-platform Python Framework for NUI"/>
+        <meta property="og:description" content="Open source Python framework for rapid development of applications
+                that make use of innovative user interfaces, such as multi-touch apps."/>
         <meta property="og:url" content="http://kivy.org/"/>
         <meta property="og:locale" content="en_US"/>
         <meta property="og:image" content="http://kivy.org/logos/kivy-logo-black-256.png"/>


### PR DESCRIPTION
For seo purposes the plain "description" meta tag should be added, the Open Graph one is used mainly by social networks. This will set the correct description in Google results.
