### PR TITLE
Changed Link to installation guide on fedora to work

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,7 +348,7 @@
                                                 </a></p>
                                         </td>
                                         <td>
-                                                <p><a href="http://akivy.org/docs/installation/installation-linux.html#fedora">
+                                                <p><a href="http://kivy.org/docs/installation/installation-linux.html#fedora">
                                                         Installation-guide for Fedora
                                                 </a>
                                                 </p>


### PR DESCRIPTION
Download page had a typo int he link to the fedora installation guide
