### PR TITLE
Correct youtube link for Richard Larkin's talk

### DIFF
--- a/index.html
+++ b/index.html
@@ -815,7 +815,7 @@
                                 <li>
                                         <img class="preview" src="images/talks/talk-pyconza13.png" alt="" />
                                         <img src="images/talks/us.png" title="en" alt="" />
-                                        <a href="http://youtu.be/URUZOegA57g">Our journey to Kivy</a>
+                                        <a href="https://youtu.be/Nn5Mms4oyGM">Our journey to Kivy</a>
                                         (<a href="https://github.com/Zen-CODE/kivybits/tree/master/PyCon/ZA%202013">slides</a>)
                                         3 Octobler 2013 - Richard Larkin<br />
                                         PyconZA 2013 in Cape Town, South Africa<br />


### PR DESCRIPTION
Replaces the broken youtube link with working one from the kivy's youtube channel.