### PR TITLE
Installation Instructions for Raspberry Pi

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,6 +206,9 @@
                         The current version is <span class="hl">1.9.1</span>, released on Jan 1st, 2016.
                                 <a href="#changelog" rel="panel">Read the Changelog</a>.
                         </p>
+                        <p>
+                                Installation instructions can be found <a href="https://kivy.org/docs/gettingstarted/installation.html">here</a>.
+                        </p>
 
                         <table class="downloads">
                                 <tr>
@@ -391,6 +394,9 @@
                                                 </a> - Image for Raspberry Pi containing Kivy
                                         </td>
                                         <td>
+                                                <a href="https://kivy.org/docs/installation/installation-rpi.html">
+                                                        Installation for Raspberry Pi
+                                                </a>
                                         </td>
                                         <td>
                                                 532 Mb


### PR DESCRIPTION
Added link to general installation instructions ([https://kivy.org/docs/gettingstarted/installation.html](https://kivy.org/docs/gettingstarted/installation.html)) as well as to raspberry pi installation instructions ([https://kivy.org/docs/installation/installation-rpi.html](https://kivy.org/docs/installation/installation-rpi.html))