### PR TITLE
Add function for nightly wheel url

### DIFF
--- a/js/kivy.js
+++ b/js/kivy.js
@@ -9,7 +9,7 @@ function checkPanelNavigation() {
 			triggerNav({ id: hash });
 		}
 	}
-	setTimeout('checkPanelNavigation()', 150)
+	setTimeout('checkPanelNavigation()', 150);
 }
 
 function selectPanel(name) {
@@ -84,7 +84,7 @@ $(document).ready(function () {
 	//
 	// PANELS
 	//
-	$('div.panel').hide()
+	$('div.panel').hide();
 	$('#menu .navigation').find('a[href^="#"]').click(selectNav);
 	$("a[rel^='panel']").click(selectNav);
 
@@ -100,7 +100,7 @@ $(document).ready(function () {
 	//
 	// Platforms
 	//
-	$('table.downloads tr').removeClass('selected')
+	$('table.downloads tr').removeClass('selected');
 
 	var dos = $.client.os;
 	if ( dos == 'Windows' ) {
@@ -141,31 +141,73 @@ $(document).ready(function () {
 	checkPanelNavigation();
 });
 
-//get url for nightly build
-//ajax from https://github.com/padolsey-archive/jquery.fn/tree/master/cross-domain-ajax
+// get url for nightly wheel
+// ajax from https://github.com/padolsey-archive/jquery.fn/tree/master/cross-domain-ajax
+// <button onclick="getNightly('cp27','win32');">Get wheel!</button>
 
-//leading zeros for date
+// leading zeros for date
 function addZeros(num, size) {
-    var s = num+"";
-    while (s.length < size) s = "0" + s;
+    var s = num + '';
+    while (s.length < size) s = '0' + s;
     return s;
 }
 
-//getNightly('cp27','win32'); for cpXY and win32, win_amd64
-function getNightly(pyVer, arch){
-    var drive_url = 'https://drive.google.com/folderview?id=0B1_HB9J8mZepOV81UHpDbmg5SWM&usp=sharing#list';
-    jQuery.ajax = (function(_ajax){
+function wheelUrl(fromAjax, pyVer, arch) {
+    var prefixUrl = 'https://docs.google.com/uc?id=';
+    var fileID = 'entry-([a-zA-Z0-9\\-]*?)';
+    var htmlGarbage = '(?:" role="link" tabindex="0">\
+<div class="flip-entry-info"><div class="flip-entry-visual">\
+<div class="flip-entry-visual-card"><div class="flip-entry-icon">\
+<img alt="Compressed Archive" src="https:\\/\\/ssl.gstatic.com\\/do\
+cs\\/doclist\\/images\\/icon_9_archive_xl128\\.png"\\/><\\/div>\
+<\\/div><\\/div><div class="flip-entry-list-icon"><img alt="" src="\
+https:\\/\\/ssl\\.gstatic\\.com\\/docs\\/doclist\\/images\\/icon_9_\
+archive_list\\.png"\\/><\\/div><div class="flip-entry-title">)';
+    var wheel = '(Kivy-\\d\\.\\d\\.\\d)(\\.\\w{4}_$date$_git\\_?\\w\
+{7}-$pyVer$)(-none|_\\d{8}_git_\\w{7}-$pyVer$m)(-$arch$.whl)';
+    var date = new Date();
+    var yesterday = addZeros(date.getDate() - 1, 2);
+    var month = addZeros(date.getMonth() + 1, 2);
+    var year = date.getFullYear();
+    date = yesterday + month + year;
+    wheel = wheel.replace("$date$", date).replace("$pyVer$", pyVer);
+    wheel = wheel.replace("$pyVer$", pyVer).replace("$arch$", arch);
+    var regex = fileID + htmlGarbage + wheel;
+    var text = fromAjax.responseText;
+    try {
+        whlUrl = prefixUrl + text.match(new RegExp(regex))[1];
+        var win = window.open(whlUrl, '_blank');
+        if (win) {
+            win.focus();
+        }
+        else {
+          alert('Please allow pop-ups for this page!');
+        }
+    }
+    catch (e) {
+        alert('No nightly wheel is available yet!');
+    }
+}
+
+// getNightly('cp27', 'win32'); for cpXY and win32, win_amd64
+function getNightly(pyVer, arch) {
+    var whlURL;
+    var driveUrl = 'https://drive.google.com/folderview?id=0B1_HB9J8\
+mZepOV81UHpDbmg5SWM&usp=sharing#list';
+    jQuery.ajax = (function(_ajax) {
         var protocol = location.protocol,
             hostname = location.hostname,
             exRegex = RegExp(protocol + '//' + hostname),
-            YQL = 'http' + (/^https/.test(protocol)?'s':'') + '://query.yahooapis.com/v1/public/yql?callback=?',
+            YQL = 'http' + (/^https/.test(protocol)?'s':'') + '://query\
+.yahooapis.com/v1/public/yql?callback=?',
             query = 'select * from html where url="{URL}" and xpath="*"';
         function isExternal(url) {
             return !exRegex.test(url) && /:\/\//.test(url);
         }
         return function(o) {
             var url = o.url;
-            if ( /get/i.test(o.type) && !/json/i.test(o.dataType) && isExternal(url) ) {
+            if (/get/i.test(o.type) && !/json/i.test(o.dataType) &&
+                isExternal(url)) {
                 o.url = YQL;
                 o.dataType = 'json';
                 o.data = {
@@ -181,12 +223,13 @@ function getNightly(pyVer, arch){
                     o.success = o.complete;
                     delete o.complete;
                 }
-                o.success = (function(_success){
+                o.success = (function(_success) {
                     return function(data) {
+                        var rx = /<script[^>]+?\/>|<script(.|\s)*?\/script>/gi;
                         if (_success) {
                             _success.call(this, {
                                 responseText: data.results[0]
-                                    .replace(/<script[^>]+?\/>|<script(.|\s)*?\/script>/gi, '')
+                                    .replace(rx, '')
                             }, 'success');
                         }
                     };
@@ -196,32 +239,11 @@ function getNightly(pyVer, arch){
         };
     })(jQuery.ajax);
     $.ajax({
-        url: drive_url,
+        url: driveUrl,
         type: 'GET',
+        async: false,
         success: function(res) {
-            var prefixUrl = "https://docs.google.com/uc?id=";
-            var urlPart = String(/entry-([a-zA-Z0-9\-]*?)/);
-            var htmlGarbage = String(/(?:" role="link" tabindex="0"><div class="flip-entry-info"><div class="flip-entry-visual"><div class="flip-entry-visual-card"><div class="flip-entry-icon"><img alt="Compressed Archive" src="https:\/\/ssl.gstatic.com\/docs\/doclist\/images\/icon_9_archive_xl128\.png"\/><\/div><\/div><\/div><div class="flip-entry-list-icon"><img alt="" src="https:\/\/ssl\.gstatic\.com\/docs\/doclist\/images\/icon_9_archive_list\.png"\/><\/div><div class="flip-entry-title">)/);
-            var wheel = String(/(Kivy-\d\.\d\.\d)(\.\w{4}_$date$_git\_?\w{7}-$pyVer$)(-none|_\d{8}_git_\w{7}-$pyVer$m)(-$arch$.whl)/);
-            var date = new Date();
-            var yesterday = addZeros(date.getDate()-1, 2);
-            var month = addZeros(date.getMonth()+1, 2);
-            var year = date.getFullYear();
-            date = yesterday+month+year;
-            wheel = wheel.replace("$date$",date).replace("$pyVer$",pyVer);
-            wheel = wheel.replace("$pyVer$",pyVer).replace("$arch$",arch);
-            var patt = new RegExp(urlPart.slice(1,-1)+htmlGarbage.slice(1,-1)+wheel.slice(1,-1));
-            var text = res.responseText;
-            var result;
-            try{
-                result = text.match(patt);
-                var wheelUrl = prefixUrl+result[1];
-                console.log(wheelUrl);
-                return wheelUrl;
-            }
-            catch(e){
-                alert('No nightly-build wheel is available yet!');
-            }
+            wheelUrl(res, pyVer, arch);
         }
     });
 }

--- a/js/kivy.js
+++ b/js/kivy.js
@@ -140,3 +140,88 @@ $(document).ready(function () {
 
 	checkPanelNavigation();
 });
+
+//get url for nightly build
+//ajax from https://github.com/padolsey-archive/jquery.fn/tree/master/cross-domain-ajax
+
+//leading zeros for date
+function addZeros(num, size) {
+    var s = num+"";
+    while (s.length < size) s = "0" + s;
+    return s;
+}
+
+//getNightly('cp27','win32'); for cpXY and win32, win_amd64
+function getNightly(pyVer, arch){
+    var drive_url = 'https://drive.google.com/folderview?id=0B1_HB9J8mZepOV81UHpDbmg5SWM&usp=sharing#list';
+    jQuery.ajax = (function(_ajax){
+        var protocol = location.protocol,
+            hostname = location.hostname,
+            exRegex = RegExp(protocol + '//' + hostname),
+            YQL = 'http' + (/^https/.test(protocol)?'s':'') + '://query.yahooapis.com/v1/public/yql?callback=?',
+            query = 'select * from html where url="{URL}" and xpath="*"';
+        function isExternal(url) {
+            return !exRegex.test(url) && /:\/\//.test(url);
+        }
+        return function(o) {
+            var url = o.url;
+            if ( /get/i.test(o.type) && !/json/i.test(o.dataType) && isExternal(url) ) {
+                o.url = YQL;
+                o.dataType = 'json';
+                o.data = {
+                    q: query.replace(
+                        '{URL}',
+                        url + (o.data ?
+                            (/\?/.test(url) ? '&' : '?') + jQuery.param(o.data)
+                        : '')
+                    ),
+                    format: 'xml'
+                };
+                if (!o.success && o.complete) {
+                    o.success = o.complete;
+                    delete o.complete;
+                }
+                o.success = (function(_success){
+                    return function(data) {
+                        if (_success) {
+                            _success.call(this, {
+                                responseText: data.results[0]
+                                    .replace(/<script[^>]+?\/>|<script(.|\s)*?\/script>/gi, '')
+                            }, 'success');
+                        }
+                    };
+                })(o.success);
+            }
+            return _ajax.apply(this, arguments);
+        };
+    })(jQuery.ajax);
+    $.ajax({
+        url: drive_url,
+        type: 'GET',
+        success: function(res) {
+            var prefixUrl = "https://docs.google.com/uc?id=";
+            var urlPart = String(/entry-([a-zA-Z0-9\-]*?)/);
+            var htmlGarbage = String(/(?:" role="link" tabindex="0"><div class="flip-entry-info"><div class="flip-entry-visual"><div class="flip-entry-visual-card"><div class="flip-entry-icon"><img alt="Compressed Archive" src="https:\/\/ssl.gstatic.com\/docs\/doclist\/images\/icon_9_archive_xl128\.png"\/><\/div><\/div><\/div><div class="flip-entry-list-icon"><img alt="" src="https:\/\/ssl\.gstatic\.com\/docs\/doclist\/images\/icon_9_archive_list\.png"\/><\/div><div class="flip-entry-title">)/);
+            var wheel = String(/(Kivy-\d\.\d\.\d)(\.\w{4}_$date$_git\_?\w{7}-$pyVer$)(-none|_\d{8}_git_\w{7}-$pyVer$m)(-$arch$.whl)/);
+            var date = new Date();
+            var yesterday = addZeros(date.getDate()-1, 2);
+            var month = addZeros(date.getMonth()+1, 2);
+            var year = date.getFullYear();
+            date = yesterday+month+year;
+            wheel = wheel.replace("$date$",date).replace("$pyVer$",pyVer);
+            wheel = wheel.replace("$pyVer$",pyVer).replace("$arch$",arch);
+            var patt = new RegExp(urlPart.slice(1,-1)+htmlGarbage.slice(1,-1)+wheel.slice(1,-1));
+            var text = res.responseText;
+            var result;
+            try{
+                result = text.match(patt);
+                var wheelUrl = prefixUrl+result[1];
+                console.log(wheelUrl);
+                return wheelUrl;
+            }
+            catch(e){
+                alert('No nightly-build wheel is available yet!');
+            }
+        }
+    });
+}


### PR DESCRIPTION
Create a function that catches source code, matches for latest nightly wheel depending on arguments and returns url for that.

As @dessant said that button may be a good idea, this can be easily used like:
`<button onclick="getNightly('cp34','win_amd64');">Get Py34_64bit</button>`

directly in the [docs](https://kivy.org/docs/installation/installation-windows.html) as the docs already use `kivy.js` 

One button may be enough with some dropdown for selecting versions, or I can rewrite it so it'd automatically open the url(in a case that there'd be four buttons).

**Edit2:** Ready for merging now.