### PR TITLE
Fixes display of links for PyDelhi Conf project

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -123,7 +123,7 @@
     ],
     "footer": [
       "<a href='https://github.com/pydelhi/pydelhi_mobile'>Source Code</a>",
-      "<a href='https://conference.pydelhi.org/'>Conference</a>"
+      " - <a href='https://conference.pydelhi.org/'>Conference Website</a>"
     ]
   },
   {


### PR DESCRIPTION
The two links mentioned in the projects section for PyDelhi Conf didn't have any space between them. So, were visually unpleasant. Fixed that.

Before:
<img width="517" alt="screen shot 2017-05-08 at 1 23 16 pm" src="https://cloud.githubusercontent.com/assets/8039608/25795130/9dcf7dfc-33f1-11e7-952f-fa62f1b88917.png">


After: 
<img width="510" alt="screen shot 2017-05-08 at 1 23 22 pm" src="https://cloud.githubusercontent.com/assets/8039608/25795135/a3a7ca18-33f1-11e7-8505-307a209654c2.png">

