### PR TITLE
Do not recommend installing Kivy.app for new users

### DIFF
--- a/index.html
+++ b/index.html
@@ -239,15 +239,6 @@
                                         </td>
                                         <td>
                                                 Install using pip, follow the instructions <a href="https://kivy.org/docs/installation/installation-osx.html#using-homebrew-with-pip">here</a><br/><br/>
-
-                                                Portable packages:
-                                                <ul>
-                                                <li><a href="https://drive.google.com/open?id=0B1WO07-OL50_Zm5udkRUZDNfaTg">Python 2.7</a></li>
-                                                <li>Python 3.5 coming soon</li>
-                                                <!--
-                                                <li><a href="https://drive.google.com/open?id=0B1WO07-OL50_a3FpU3FQWjctdDg">Python 3.5</a></li>
-                                                -->
-                                                </ul>
                                         </td>
                                         <td>
                                                 <a href="//kivy.org/docs/installation/installation-osx.html">Installation for macOS</a>


### PR DESCRIPTION
Besides the existing issues with Kivy.app which prompted us to recommend installing Kivy dependencies with Homebrew, Kivy.app does not integrate well with an existing dev environment.

Existing users can discover this alternate method of installation from the docs, but we should not expose new users to impaired experiences.

https://kivy.org/docs/installation/installation-osx.html#using-the-kivy-app