### PR TITLE
Corrections for the download panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,15 +330,7 @@
                                                 Fedora
                                         </td>
                                         <td>
-                                                <p>
-                                                <a href="http://download.opensuse.org/repositories/home:/thopiekar:/kivy/Fedora_21/">
-                                                        Repository for Fedora 21
-                                                </a>
-                                                <br/>
-                                                <a href="http://download.opensuse.org/repositories/home:/thopiekar:/kivy/Fedora_20/">
-                                                        Repository for Fedora 20
-                                                </a>
-                                                </p>
+                                                ...
                                         </td>
                                         <td>
                                                 <p><a href="//kivy.org/docs/installation/installation-linux.html#fedora">

--- a/index.html
+++ b/index.html
@@ -263,7 +263,7 @@
                                                 (<a href="https://github.com/kivy/kivy/archive/1.10.0.tar.gz">Mirror</a>)
                                         </td>
                                         <td>
-                                                <a href="//kivy.org/docs/installation/installation-linux.html#ubuntu-11-10-or-newer">Installation for Ubuntu</a>
+                                                <a href="//kivy.org/docs/installation/installation-linux.html">Installation on Linux</a>
                                         </td>
                                         <td>
                                                 24 Mb

--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
                                                 Install using pip, follow the instructions <a href="https://kivy.org/docs/installation/installation-windows.html#install-win-dist">here</a>
                                         </td>
                                         <td>
-                                                <a href="//kivy.org/docs/installation/installation-windows.html">Installation for Windows</a>
+                                                <a href="//kivy.org/docs/installation/installation-windows.html">Installation on Windows</a>
                                         </td>
                                         <td>
                                                 ...
@@ -245,7 +245,7 @@
                                         <td>
 						<a href="https://drive.google.com/open?id=1auK2-myL34di_mzh-QHgjgl3BbXQKMWL">Python 3 123.4MB OSX > 10.12.5</a>
 						<a href="https://drive.google.com/open?id=1SGS4vtJ0pNoqCEZ0CTdalHs97fgWUkYV">Python 2 90.6MB OSX > 10.12.5</a>
-                                                <a href="//kivy.org/docs/installation/installation-osx.html">Installation for macOS</a>
+                                                <a href="//kivy.org/docs/installation/installation-osx.html">Installation on macOS</a>
                                         </td>
                                         <td>
                                                 ...
@@ -316,7 +316,7 @@
                                         </td>
                                         <td>
                                                 <p><a href="//kivy.org/docs/installation/installation-linux.html#opensuse">
-                                                        Installation-guide for OpenSuSE
+                                                        Installation on OpenSuSE
                                                 </a>
                                                 </p>
                                         </td>
@@ -334,7 +334,7 @@
                                         </td>
                                         <td>
                                                 <p><a href="//kivy.org/docs/installation/installation-linux.html#fedora">
-                                                        Installation-guide for Fedora
+                                                        Installation on Fedora
                                                 </a>
                                                 </p>
                                         </td>
@@ -374,7 +374,7 @@
                                         </td>
                                         <td>
                                                 <a href="https://kivy.org/docs/installation/installation-rpi.html">
-                                                        Installation for Raspberry Pi
+                                                        Installation on Raspberry Pi
                                                 </a>
                                         </td>
                                         <td>
@@ -393,7 +393,7 @@
                                         </td>
                                         <td>
                                                 <a href="https://slackbuilds.org/repository/14.2/libraries/Kivy/">
-                                                        Installation for SlackWare
+                                                        Installation on SlackWare
                                                 </a>
                                         </td>
                                         <td>

--- a/index.html
+++ b/index.html
@@ -294,29 +294,15 @@
                                 </tr>
                                 <tr class="os-opensuse">
                                         <td>
-                                                <img src="images/os_opensuse.png" alt="Opensuse"/>
-                                                Opensuse
+                                                <img src="images/os_opensuse.png" alt="OpenSUSE"/>
+                                                OpenSUSE
                                         </td>
                                         <td>
-                                                <p><a href="http://software.opensuse.org/ymp/devel:languages:python/openSUSE_Factory/python-Kivy.ymp?base=openSUSE%3AFactory&query=python-Kivy">
-                                                        One-Click-Installation for Factory
-                                                </a>
-                                                <br/>
-                                                <a href="http://software.opensuse.org/ymp/devel:languages:python/openSUSE_13.2/python-Kivy.ymp?base=openSUSE%3A13.1&query=python-Kivy">
-                                                        One-Click-Installation for 13.2
-                                                </a>
-                                                <br/>
-                                                <a href="http://software.opensuse.org/ymp/devel:languages:python/openSUSE_13.1/python-Kivy.ymp?base=openSUSE%3A13.1&query=python-Kivy">
-                                                        One-Click-Installation for 13.1
-                                                </a>
-                                                <br/>
-                                                <a href="http://software.opensuse.org/ymp/devel:languages:python/openSUSE_Factory/python-Kivy.ymp?base=openSUSE%3AFactory&query=python-Kivy">
-                                                        One-Click-Installation for Tumbleweed
-                                                </a></p>
+                                                ...
                                         </td>
                                         <td>
                                                 <p><a href="//kivy.org/docs/installation/installation-linux.html#opensuse">
-                                                        Installation on OpenSuSE
+                                                        Installation on OpenSUSE
                                                 </a>
                                                 </p>
                                         </td>


### PR DESCRIPTION
Please review; **squash** before merging.

- Several links are broken, removed
- Changed phrasing

open:
- macOS should have the files in the `File` column, but not sure why they're pointing at a Google Drive.
- Should point to docs in Ubuntu PPA row, too
- Need to clean up Linux instructions, then maybe revisit