### PR TITLE
Update Slackware source tar.gz link to v1.10.1

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,7 +403,7 @@
                                                 Slackware
                                         </td>
                                         <td>
-                                                <a href="https://github.com/kivy/kivy/archive/1.10.0.tar.gz">
+                                                <a href="https://github.com/kivy/kivy/archive/1.10.1.tar.gz">
                                                         SlackBuilds
                                                 </a> - Downloads for installing Kivy on Slackware
                                         </td>


### PR DESCRIPTION
Slackware has updated to v1.10.1, now the link can be updated.