### PR TITLE
Updated kognitivo information on Kivy website gallery section

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -145,7 +145,7 @@
       "See your daily and weekly productivity in graphs"
     ],
     "footer": [
-      "<a href='https://play.google.com/store/apps/details?id=org.kognitivo.kognitivo'>Google Play</a>"
+      "<a href='https://github.com/eviltnan/kognitivo'>Source Code</a>"
     ]
   },
   {


### PR DESCRIPTION
Kognitivo Google play link is crashing. Removed google play link of kognitivo by replacing it with source code of github repository.