### PR TITLE
Updated link to fresk interactive

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -324,7 +324,7 @@
     ],
     "footer": [
       "<a href='http://fresklabs.com/projects/bargenius'>Website</a>",
-      " - by <a href='http://fresk.co/'>fresk interactive</a>"
+      " - by <a href='http://fresklabs.com/'>fresk interactive</a>"
     ]
   },
   {
@@ -380,7 +380,7 @@
     ],
     "footer": [
       "<a href='http://thenobooth.com/'>Website</a>",
-      " - by <a href='http://fresk.co/'>fresk interactive</a>"
+      " - by <a href='http://fresklabs.com/'>fresk interactive</a>"
     ]
   },
   {


### PR DESCRIPTION
The link to fresk interactive is fresklabs.com instead of fresk.co