### PR TITLE
Update Google Search Console meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
         <meta name="description" content="Open source Python framework for rapid development of applications
         that make use of innovative user interfaces, such as multi-touch apps."/>
         <meta name="twitter:site" content="@kivyframework"/>
-        <meta name="google-site-verification" content="MJm2FgAH_rkrbGvWnTntXs1_qfJPIn3t-6V-eVVj9JI" />
+        <meta name="google-site-verification" content="kfZL1Qs64GvRmH9L944D8lbmb-aVuSSb-toeOEGTxPY" />
         <meta property="og:title" content="Kivy: Cross-platform Python Framework for NUI"/>
         <meta property="og:description" content="Open source Python framework for rapid development of applications
         that make use of innovative user interfaces, such as multi-touch apps."/>


### PR DESCRIPTION
The site is verified from my own account in the search console, and the rest of the team are delegated owners. This change adds the kivy.buildbot account as a verified owner, so that team access does not depend on my account.

You can read more about user roles here:
https://support.google.com/webmasters/answer/2453966?hl=en