### PR TITLE
remove references to the kivy VM

### DIFF
--- a/index.html
+++ b/index.html
@@ -440,24 +440,6 @@
                         <h2>IOS</h2>
                         <p>Read the documentation on <a href="//kivy.org/docs/guide/packaging-ios.html">Packaging for IOS</a></p>
 
-                        <h2>Virtual Machine (for Android/buildozer)</h2>
-                        <p>
-                            Version 2.0, released the 13 May 2017 (<a href="https://raw.githubusercontent.com/kivy/buildozer/master/buildozer/tools/packer/CHANGELOG">Changelog</a>)
-                        <p>
-                        <p class="nomargin">
-                        A Virtual Machine for Virtualbox:
-                            <a href="https://github.com/kivy/buildozer">buildozer</a>,
-                            <a href="https://github.com/kivy/python-for-android">python-for-android</a>, and others pre-requisites
-                            ready to use for generating an Android/APK (1.2GB):
-                        </p>
-                        <ul>
-                            <li>Torrent (preferred): <a href="http://txzone.net/files/torrents/kivy-buildozer-vm.torrent">kivy-buildozer-vm.torrent</a></li>
-                            <li>Direct: <a href="http://txzone.net/files/torrents/kivy-buildozer-vm-2.0.zip">kivy-buildozer-vm-2.0.zip</a></li>
-                        </ul>
-                        <p>
-                        For this Virtual Machine, the user is "kivy" and the password is "kivy".
-                        </p>
-
                         <h2 style="clear: left;">Source code</h2>
                         <pre style="padding: 10px; background-color: #E0E0E0;">git clone <a href="https://github.com/kivy/kivy">https://github.com/kivy/kivy</a></pre>
                         <p>


### PR DESCRIPTION
until we provide an alternative