### PR TITLE
Revert "Add link to Doku"

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,6 @@
                 <ul class="navigation">
                         <li><a class="piwik_link" href="#home">Home</a></li>
                         <li><a class="piwik_link" href="#download">Download</a></li>
-                        <li><a class="piwik_link" href="https://kivy.org/doc/stable/">Documentation</a></li>
                         <li><a class="piwik_link" href="#gallery">Gallery</a></li>
                         <li><a class="piwik_link" href="#support">Help</a></li>
                         <li><a class="piwik_link" href="https://opencollective.com/kivy">Donate</a></li>


### PR DESCRIPTION
Reverts kivy/kivy-website#111

Front page links have disappeared.