### PR TITLE
Add link to Documentation on landingpage

### DIFF
--- a/css/kivy.css
+++ b/css/kivy.css
@@ -61,7 +61,7 @@ a.selected {
 #logo {
 		padding: 25px 0px;
 		float: left;
-		width: 300px;
+		width: 200px;
 }
 
 #menu {

--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
                         <li><a class="piwik_link" href="#download">Download</a></li>
                         <li><a class="piwik_link" href="#gallery">Gallery</a></li>
                         <li><a class="piwik_link" href="#support">Help</a></li>
+                        <li><a class="piwik_link" href="https://kivy.org/doc/stable/">Documentation</a></li>
                         <li><a class="piwik_link" href="https://opencollective.com/kivy">Donate</a></li>
                         <li><a class="piwik_link" href="#aboutus">About</a></li>
                         <li><a class="piwik_link" href="//kivy.org/planet">Blog</a></li>


### PR DESCRIPTION
Like mentioned in issue #104 I shrank the Logo by 100px and named the Link Documentation like in the Original. 