### PR TITLE
Add discord icon/link to chat.kivy.org to social media icons

### DIFF
--- a/css/sprites.css
+++ b/css/sprites.css
@@ -1,4 +1,4 @@
-.icon-facebook, .icon-github, .icon-gplus, .icon-twitter, .icon-youtube{
+.icon-facebook, .icon-github, .icon-gplus, .icon-twitter, .icon-youtube, .icon-discord{
 	background: url(sprites.png) no-repeat;
 	display: inline-block;
 }
@@ -29,6 +29,11 @@
 
 .icon-youtube{
 	background-position: 0 0;
+	width: 24px;
+	height: 24px;
+}
+.icon-discord{
+	background-position: -124px 0;
 	width: 24px;
 	height: 24px;
 }

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
 			<a href="https://www.youtube.com/user/kivyframework" class="icon-youtube"></a>
 			<a href="https://www.facebook.com/kivyframework" class="icon-facebook"></a>
 			<a href="https://twitter.com/kivyframework" class="icon-twitter"></a>
+			<a href="https://chat.kivy.org/" class="icon-discord"></a>
 		</div>
         <div id="logo">
                 <a href="//kivy.org/">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22759/97105839-427cbb00-16be-11eb-9685-2a0e3c723ac8.png)
