### PR TITLE
Kivy 2.3.0 has been released. Update announcement.

### DIFF
--- a/content/ext/kivy.json
+++ b/content/ext/kivy.json
@@ -1,8 +1,8 @@
 {
   "framework": "Kivy",
   "url": "http://kivy.org",
-  "framework_current_version" : "2.2.1",
-  "comparison_data_last_update" : "2023-06-17",
+  "framework_current_version" : "2.3.0",
+  "comparison_data_last_update" : "2024-01-05",
 
   "tutorial_url": "http://kivy.org/docs/tutorials/pong.html",
   "license": "mit-license",

--- a/templates/components/header.html
+++ b/templates/components/header.html
@@ -34,9 +34,9 @@
     <!-- Start: Announce header -->
     <div class="h-8 flex px-2 sm:px-5 justify-between bg-gradient-to-r from-sky-500 to-fuchsia-500 items-center">
         <p class="font-bold text-white text-sm whitespace-nowrap">
-            Kivy 2.2.1 has been released!
+            Kivy 2.3.0 has been released!
         </p>
-        <a href="https://github.com/kivy/kivy/releases/tag/2.2.1" class="bg-white rounded-lg text-xs sm:text-sm px-1 sm:px-2 py-0.5 text-bold whitespace-nowrap">
+        <a href="https://github.com/kivy/kivy/releases/tag/2.3.0" class="bg-white rounded-lg text-xs sm:text-sm px-1 sm:px-2 py-0.5 text-bold whitespace-nowrap">
             LEARN MORE
         </a>
     </div>


### PR DESCRIPTION
🥳 Kivy **2.3.0** has been released 🥳 

- Update announcement header
- Update external check file